### PR TITLE
feat: #5 코스 생성,조회,수정,삭제 구현

### DIFF
--- a/makourse/course/models.py
+++ b/makourse/course/models.py
@@ -3,6 +3,7 @@ from account.models import *
 
 class MyPlace(models.Model): # 나만의 장소
     place_name = models.CharField(max_length=10)
+
     address = models.CharField(max_length=150)
     latitude = models.FloatField(default=0.0)  # 위도
     longitude = models.FloatField(default=0.0)  # 경도
@@ -15,14 +16,15 @@ class MyPlace(models.Model): # 나만의 장소
 
 
 class Schedule(models.Model): # 일정(코스)
-    group = models.OneToOneField(UserGroup, on_delete=models.CASCADE, related_name='schedule')  # 일대일 관계 설정
-    meet_date_first = models.DateField(null=True) # 만나는 날짜(최대 3개로 설정하게 하려면 조금 복잡해서 일단 이렇게 해놓음..)
-    meet_date_second = models.DateField(null=True)
-    meet_date_third = models.DateField(null=True)
+    group = models.OneToOneField(UserGroup, on_delete=models.CASCADE, related_name='schedule', null=True)  # 일대일 관계 설정
+    meet_date_first = models.DateTimeField(null=True) # 만나는 날짜(최대 3개로 설정하게 하려면 조금 복잡해서 일단 이렇게 해놓음..)
+    meet_date_second = models.DateTimeField(null=True) # 2024-12-10T15:30:00 식으로 json 받기
+    meet_date_third = models.DateTimeField(null=True)
     course_name = models.CharField(max_length=20, null=True)
     meet_place = models.CharField(max_length=50, null=True)
     latitude = models.FloatField(default=0.0)  # 만나는 장소의 위도
     longitude = models.FloatField(default=0.0)  # 만나는 장소의 경도
+    created_at = models.DateField(auto_now_add=True)
 
     def __str__(self):
         return self.course_name
@@ -30,9 +32,11 @@ class Schedule(models.Model): # 일정(코스)
 
 class ScheduleEntry(models.Model): # 각 코스의 일정들
     schedule = models.ForeignKey(Schedule, on_delete=models.CASCADE) # 코스의 외래키
+
     num = models.IntegerField() # 순번이 차례로 증가하게 해야되는지 아니면 나중에 결정해야하는지..
     entry_name = models.CharField(max_length=10) # 일정의 이름
     time = models.TimeField() # 그 일정의 시간
+
     open_time = models.TimeField() # 오픈 시간
     close_time = models.TimeField() # 마감시간
     # 운영시간은 이렇게 오픈, 마감 시간으로 따로 저장
@@ -67,10 +71,13 @@ class ScheduleEntry(models.Model): # 각 코스의 일정들
 
 class AlternativePlace(models.Model): # 대안장소
     schedule_entry = models.ForeignKey(ScheduleEntry, on_delete=models.CASCADE)
+
     address = models.CharField(max_length=150)
     latitude = models.FloatField(default=0.0)  # 위도
     longitude = models.FloatField(default=0.0)  # 경도
+
     name = models.CharField(max_length=10) # 대안장소 이름
+
     category =  models.CharField(max_length=10, null=True)
 
     def __str__(self):

--- a/makourse/course/serializers.py
+++ b/makourse/course/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+from .models import *
+
+class CreateCourseSerializser(serializers.ModelSerializer):
+    class Meta:
+        model = Schedule
+        fields = '__all__' 
+
+    # def validate(self, data): # 처음에 날짜만 받을거여서 넣어봤는데 필요한지는 모르겠음
+    #     request_method = self.context.get('request').method
+    #     if request_method == 'POST':
+    #         required_fields = ['meet_date_first', 'meet_date_second','meet_date_third']
+
+class ListCourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Schedule
+        fields = ['pk', 'course_name', 'meet_date_first', 'group']

--- a/makourse/course/serializers.py
+++ b/makourse/course/serializers.py
@@ -15,3 +15,8 @@ class ListCourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Schedule
         fields = ['pk', 'course_name', 'meet_date_first', 'group']
+
+class ScheduleEntrySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ScheduleEntry
+        fields = ['pk', 'num', 'entry_name']

--- a/makourse/course/urls.py
+++ b/makourse/course/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.urls import path
+from .views import *
 
 
 urlpatterns = [
-    
+    path('schedule/', ScheduleUpdateView.as_view()), # 일정(코스) 등록(post) or 목록 조회(get)
+    path('schedule/<int:pk>/', ScheduleUpdateView.as_view()), # 일정(코스) 상세조회(get), 수정(patch), 삭제(delete)
 ]

--- a/makourse/course/views.py
+++ b/makourse/course/views.py
@@ -1,3 +1,51 @@
 from django.shortcuts import render
+from django.shortcuts import get_object_or_404
+from .serializers import *
+from .models import *
+from rest_framework.response import Response
+from rest_framework.decorators import APIView
 
-# Create your views here.
+# 일정(코스) 등록 및 수정
+class ScheduleUpdateView(APIView):
+    # 일정 등록
+    def post(self, request, *args, **kwargs):
+        serializer = CreateCourseSerializser(data=request.data, context={'request':request})
+       
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=201)
+        return Response(serializer.errors, status=400)
+
+
+    # 일정 수정
+    def patch(self, request, pk, *args, **kwargs):
+        schedule = get_object_or_404(Schedule, pk=pk)
+        serializer = CreateCourseSerializser(schedule, data=request.data, partial=True, context={'request': request})
+
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=201)
+        return Response(serializer.errors, status=400)
+
+
+    # 일정 조회
+    def get(self, request, pk=None, *args, **kwargs):
+        if pk: # 특정일정 상세조회
+            schedule = get_object_or_404(Schedule, pk=pk)
+            serializer = CreateCourseSerializser(schedule)
+
+            return Response(serializer.data, status=200)
+        else: # 일정 목록 조회
+            schedules = Schedule.objects.all()
+            serializer = ListCourseSerializer(schedules, many=True)
+            
+            return Response(serializer.data, status=200)
+
+
+    # 일정 삭제
+    def delete(self, request, pk, *args, **kwargs):
+        schedule = get_object_or_404(Schedule, pk=pk)
+        schedule.delete()
+        
+        return Response({"message": "Schdeule deleted"}, status=204)
+

--- a/makourse/course/views.py
+++ b/makourse/course/views.py
@@ -34,7 +34,9 @@ class ScheduleUpdateView(APIView):
             schedule = get_object_or_404(Schedule, pk=pk)
             serializer = CreateCourseSerializser(schedule)
 
-            return Response(serializer.data, status=200)
+            schedule_entry = ScheduleEntry.objects.filter(schedule=pk)
+            entry_serializer = ScheduleEntrySerializer(schedule_entry, many=True)
+            return Response({'course':serializer.data, 'entry':entry_serializer.data}, status=200)
         else: # 일정 목록 조회
             schedules = Schedule.objects.all()
             serializer = ListCourseSerializer(schedules, many=True)


### PR DESCRIPTION
## Related issue 🚀
- closed #5 

## Work Description 💚
- 코스 생성, 상세조회, 목록조회, 수정, 삭제 api 구현

## PR 참고 사항
- 코스 생성 : 처음 생성할 때는 만나는 날짜만 받고 생성되게 구현했습니다. (3개 다 안받아도 상관없음)
- 코스 상세조회 : 각 일정(entry) 들도 같이 조회되어야 될거같은데 아직 그 api가 없어서 일단 코스 정보만 조회되게 했슴다ㅏ
- 코스 목록조회 : 코스 목록은 피그마를 바탕으로 조회되게 했고 만나는 날짜는 first 날짜만 반환하게 했습니다.
- 코스 수정 : 처음 생성하고 그 뒤에 이름을 설정하고 하는 등은 수정 api로 할 수 있게 통일했습니다.
- 그리고 전체적으로 group은 아직 api가 없어서 null=True를 추가해줬슴다.
