### PR TITLE
Add: 그룹 멤버 조회시, user 정보 추가

### DIFF
--- a/makourse/account/models.py
+++ b/makourse/account/models.py
@@ -121,8 +121,8 @@ class GroupMembership(models.Model):
         unique_together = ('user', 'group')  # 동일한 사용자가 같은 그룹에 중복 가입하지 않도록
 
     def __str__(self):
-        schedule_name = self.group.schedule.course_name if hasattr(self.group, 'schedule') and self.group.schedule else "No Schedule"
-        return f"{schedule_name}의 {self.user.name}({self.get_role_display()})"
+        course_name = self.group.schedule.course_name if hasattr(self.group, 'schedule') and self.group.schedule else "No Schedule"
+        return f"{course_name}의 {self.user.name}({self.get_role_display()})"
         
 # user와 group은 다대다 관계인듯
 # 한 user가 여러 그룹에 들어갈 수 있고, 한 group 안에도 여러 유저가 있을 수 있으니까

--- a/makourse/account/serializers.py
+++ b/makourse/account/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from course.models import Schedule
-from .models import UserGroup, GroupMembership
+from .models import UserGroup, GroupMembership, CustomUser
 
 
 class UserGroupSerializer(serializers.ModelSerializer):
@@ -16,12 +16,18 @@ class UserGroupSerializer(serializers.ModelSerializer):
         if schedule:
             return {
                 "id": schedule.id,
-                "schedule_name": schedule.course_name
+                "course_name": schedule.course_name
             }
         return None  # 일정이 없는 경우 None 반환
 
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CustomUser
+        fields = ['id', 'name', 'email']
+
 class GroupMembershipSerializer(serializers.ModelSerializer):
     role = serializers.CharField(source='get_role_display')  # 역할 이름을 읽기 전용 필드로 추가
+    user = UserSerializer() # 유저 중첩화(이름&이메일 같이 보여주기 위해)
 
     class Meta:
         model = GroupMembership


### PR DESCRIPTION
## Related issue 🚀
- closed #{이슈_번호}

## Work Description 💚
- 그룹 멤버 목록 조회할 때 user 정보 추가 (name, email)
- 그룹 멤버 목록 조회할 때 일정 정보에서 schedule_name -> course_name으로 변경

## PR 참고 사항
- 멤버 목록 조회할 때 user 정보가 user_id만 보이길래 name이랑 email도 함께 보이게 했습니다!
- 일정 정보를 보여줄 때 필드값과 같은 course_name으로 보여주는게 좋을거 같아 수정했습니다!
