### PR TITLE
feat/#33 초대 알림 보내기/초대 알림 수락or 거절하기

### DIFF
--- a/makourse/account/serializers.py
+++ b/makourse/account/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 from course.models import Schedule
-from .models import UserGroup, GroupMembership, CustomUser
+from .models import UserGroup, GroupMembership, CustomUser,Notification
 
 
 class UserGroupSerializer(serializers.ModelSerializer):
@@ -37,3 +37,12 @@ class ScheduleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Schedule
         fields = ['id', 'group', 'course_name', 'meet_date_first', 'meet_place', 'latitude', 'longitude']
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    sender_name = serializers.CharField(source="sender.name", read_only=True)
+    group_name = serializers.CharField(source="group.schedule.course_name", read_only=True, default="일정 없음")
+
+    class Meta:
+        model = Notification
+        fields = ["id", "sender", "sender_name", "receiver", "group", "group_name", "notification_type", "content", "created_at", "is_read", "status"]

--- a/makourse/account/urls.py
+++ b/makourse/account/urls.py
@@ -20,6 +20,9 @@ urlpatterns = [
     # 초대 알림
     path('groups/<int:group_id>/invite', GroupMembershipInviteView.as_view(), name='group-invite'), # 그룹원 초대
     path('groups/<int:group_id>/invite/respond', GroupMembershipInviteResponseView.as_view(), name='group-respond'), # 그룹원 응답
+    
+    # 알림
+    path("notifications", NotificationListView.as_view(), name="notification-list"),
 
     # access token 재발급
     path('token/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),

--- a/makourse/account/urls.py
+++ b/makourse/account/urls.py
@@ -17,6 +17,10 @@ urlpatterns = [
     path('groups/<int:group_id>/join', GroupMembershipJoinView.as_view(), name='group-join'), # 그룹원 등록
     path('groups/<int:group_id>/members/<int:membership_id>', GroupMembershipDeleteView.as_view(), name='group-member-delete'), # 그룹원 삭제
 
+    # 초대 알림
+    path('groups/<int:group_id>/invite', GroupMembershipInviteView.as_view(), name='group-invite'), # 그룹원 초대
+    path('groups/<int:group_id>/invite/respond', GroupMembershipInviteResponseView.as_view(), name='group-respond'), # 그룹원 응답
+
     # access token 재발급
     path('token/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),
 

--- a/makourse/course/admin.py
+++ b/makourse/course/admin.py
@@ -16,3 +16,22 @@ admin.site.register(ScheduleEntry, ScheduleEntryAdmin)
 class AlternativePlaceAdmin(admin.ModelAdmin):
     list_display = ('pk', 'schedule_entry', 'name')
 admin.site.register(AlternativePlace)
+
+
+@admin.register(Notification)
+class NotificationAdmin(admin.ModelAdmin):
+    list_display = ('id', 'receiver', 'sender', 'notification_type', 'group', 'content', 'created_at', 'is_read', 'status')
+    list_filter = ('notification_type', 'is_read', 'status', 'created_at')
+    search_fields = ('receiver__email', 'sender__email', 'content')
+    ordering = ('-created_at',)
+    fieldsets = (
+        ('알림 정보', {
+            'fields': ('receiver', 'sender', 'notification_type', 'group', 'content', 'is_read', 'status')
+        }),
+        ('추가 정보', {
+            'fields': ('created_at',),
+            'classes': ('collapse',),
+        }),
+    )
+
+    readonly_fields = ('created_at',)  # 생성된 날짜는 읽기 전용


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #33 

## Work Description 💚
- 일단 초대 방식이 두 가지 있죠! 하나는 코드를 복사해서 카톡이든 메세지든 다른 방식으로 코드를 전달해서 코드를 입력하면 그룹원이 되는거고! 다른 하나는 그냥 바로 유저로 초대하는거죠! 그걸 구현했습니다!
- 일정에 초대하면 알림(notification) 객체가 생성되고, 그걸 통해서 초대 거절 수락하는 방식입니다!
- 알림은 초대 목적으로 사용할 수도 있지만, 다른 방식으로도 사용할 수 있을거 같아서 알림의 타입을 지정하도록 되어있어요!
- 일정/발신자/수신자/대기 상태인 초대만 필터링해서 찾고, 바디로 받은 수락/거절 여부에 따라 이 알림 객체의 상태 거절/수락으로 바뀌는 겁니다!
## PR 참고 사항
- 지금은 바디로 요청하는 유저의 아이디(이메일)을 받게 되어있는데.. 개발 끝나면 전체적으로 수정해야할 듯 합니당
- 포스트맨으로 다 돌아가는거 확인했어요!