### PR TITLE
refactor: 일정 만들기 주소 추가

### DIFF
--- a/makourse/course/models.py
+++ b/makourse/course/models.py
@@ -19,7 +19,7 @@ class Schedule(models.Model): # 일정(코스)
     meet_date_first = models.DateTimeField(null=True, blank= True) # 만나는 날짜(최대 3개로 설정하게 하려면 조금 복잡해서 일단 이렇게 해놓음..)
     meet_date_second = models.DateTimeField(null=True, blank= True) # 2024-12-10T15:30:00 식으로 json 받기
     meet_date_third = models.DateTimeField(null=True , blank= True)
-    course_name = models.CharField(max_length=20, null=True, blank= True)
+    course_name = models.CharField(max_length=20, blank=True, default="일정 이름을 정해주세요")
     meet_place = models.CharField(max_length=50, null=True, blank= True)
     address = models.CharField(null=True, blank = True, max_length=150)
     latitude = models.FloatField(default=0.0)  # 만나는 장소의 위도
@@ -33,7 +33,7 @@ class Schedule(models.Model): # 일정(코스)
 class ScheduleEntry(models.Model):  # 각 코스의 일정들
     schedule = models.ForeignKey(Schedule, on_delete=models.CASCADE)  # 코스의 외래키
     num = models.IntegerField(null=True, blank=True)  # 순번
-    entry_name = models.CharField(max_length=30)  # 일정의 이름
+    entry_name = models.CharField(max_length=30, blank=True, default="기본 일정")  # 일정의 이름
     time = models.TimeField(null=True, blank=True)  # 그 일정의 시간
     open_time = models.TimeField(null=True, blank=True)  # 오픈 시간
     close_time = models.TimeField(null=True, blank=True)  # 마감 시간
@@ -45,17 +45,20 @@ class ScheduleEntry(models.Model):  # 각 코스의 일정들
 
    # 순번 자동 증가 로직
     def save(self, *args, **kwargs):
-        if self.num is None:  # num이 None인 경우에만 자동으로 계산
+        if self.num is None:  # num이 None인 경우 자동으로 계산
             last_entry = ScheduleEntry.objects.filter(schedule=self.schedule).order_by('-num').first()
-            if last_entry:
+            if last_entry and last_entry.num is not None:
                 self.num = last_entry.num + 1  # 이전 num 값에서 +1
             else:
-                self.num = 0  # 해당 schedule의 첫 번째 항목일 경우 0으로 설정
+                self.num = 1  # 해당 schedule의 첫 번째 항목일 경우 1부터 시작
+
+        if not self.entry_name:  
+            self.entry_name = f"{self.num}번째 일정"
+
         super().save(*args, **kwargs)  # 부모 클래스의 save 호출
-            
 
     def __str__(self):
-        return self.entry_name
+        return self.entry_name if self.entry_name else f"ScheduleEntry {self.pk}"
 
 class AlternativePlace(models.Model): # 대안장소
     schedule_entry = models.ForeignKey(ScheduleEntry, on_delete=models.CASCADE)

--- a/makourse/course/models.py
+++ b/makourse/course/models.py
@@ -21,6 +21,7 @@ class Schedule(models.Model): # 일정(코스)
     meet_date_third = models.DateTimeField(null=True , blank= True)
     course_name = models.CharField(max_length=20, null=True, blank= True)
     meet_place = models.CharField(max_length=50, null=True, blank= True)
+    address = models.CharField(null=True, blank = True, max_length=150)
     latitude = models.FloatField(default=0.0)  # 만나는 장소의 위도
     longitude = models.FloatField(default=0.0)  # 만나는 장소의 경도
     created_at = models.DateField(auto_now_add=True)

--- a/makourse/course/serializers.py
+++ b/makourse/course/serializers.py
@@ -25,21 +25,18 @@ class ScheduleEntryDetailSerializer(serializers.ModelSerializer):
         model = ScheduleEntry
         fields = '__all__'
 
-class CreateCourseSerializser(serializers.ModelSerializer):
-    user_id = serializers.CharField(write_only=True)  # 요청에서 유저 ID (id 필드) 처리
 
+class CreateCourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Schedule
-        fields = '__all__'
-        # [
-        #     'meet_date_first', 'meet_date_second', 'meet_date_third',
-        #     'course_name', 'meet_place', 'latitude', 'longitude', 'user_id'
-        # ]
+        fields = '__all__'  # 모든 필드 포함
 
     def create(self, validated_data):
-        # user_id로 User 객체 가져오기
-        user_id = validated_data.pop('user_id')  # 요청 데이터에서 user_id 추출
-        user = get_object_or_404(CustomUser, id=user_id)  # User 모델의 id 필드로 조회
+        request = self.context.get('request')
+        if not request or not request.user:
+            raise serializers.ValidationError("유효한 사용자 정보를 찾을 수 없습니다.")
+
+        user = request.user  # request.user 사용
 
         # 일정 생성
         schedule = Schedule.objects.create(**validated_data)

--- a/makourse/course/views.py
+++ b/makourse/course/views.py
@@ -273,12 +273,12 @@ class ScheduleUpdateView(APIView):
     @swagger_auto_schema(
         tags=["일정(코스)"],
         operation_summary="일정(코스) 생성",
-        request_body=CreateCourseSerializser,
-        responses={201: CreateCourseSerializser, 400: "Validation Error"}
+        request_body=CreateCourseSerializer,
+        responses={201: CreateCourseSerializer, 400: "Validation Error"}
     )
     def post(self, request, *args, **kwargs):
     
-        serializer = CreateCourseSerializser(data=request.data, context={'request': request})
+        serializer = CreateCourseSerializer(data=request.data, context={'request': request})
 
         if serializer.is_valid():
             serializer.save()
@@ -294,12 +294,12 @@ class ScheduleDetailView(APIView):
     @swagger_auto_schema(
         tags=["일정(코스)"],
         operation_summary="일정 수정",
-        request_body=CreateCourseSerializser,
-        responses={200: CreateCourseSerializser, 400: "Validation Error"}
+        request_body=CreateCourseSerializer,
+        responses={200: CreateCourseSerializer, 400: "Validation Error"}
     )
     def patch(self, request, schedule_id, *args, **kwargs):
         schedule = get_object_or_404(Schedule, pk=schedule_id)
-        serializer = CreateCourseSerializser(schedule, data=request.data, partial=True, context={'request': request})
+        serializer = CreateCourseSerializer(schedule, data=request.data, partial=True, context={'request': request})
 
         if serializer.is_valid():
             serializer.save()
@@ -317,7 +317,7 @@ class ScheduleDetailView(APIView):
     def get(self, request, schedule_id, *args, **kwargs):
         # 특정일정 상세조회
         schedule = get_object_or_404(Schedule, pk=schedule_id)
-        serializer = CreateCourseSerializser(schedule)
+        serializer = CreateCourseSerializer(schedule)
 
         schedule_entry = ScheduleEntry.objects.filter(schedule=schedule_id)
         entry_serializer = ScheduleEntrySerializer(schedule_entry, many=True)

--- a/makourse/makourse/settings.py
+++ b/makourse/makourse/settings.py
@@ -100,7 +100,7 @@ REST_USE_JWT = True
 
 SIMPLE_JWT = {
     'SIGNING_KEY': 'hellomakourse',
-    'ACCESS_TOKEN_LIFETIME': timedelta(hours=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=30),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Related issue 🚀
- closed #{이슈_번호}

## Work Description 💚
- 그냥 간단하게 모델에서 주소를 추가해줬습니다!
- 근데 문제가 있는게 세부 일정 생성할 때 아예 0번부터 시작한단 말이죠?! 0번이 만날 장소고,, 그게 겹치는게 걸립니다! 아예 만날 장소 자체를 0번 세부 일정으로 들어가게 해야할지..? 아니면 그대로 냅둘지! 
- 만약 세부 일정으로 자동 생성하게 되면,,api를 싹 갈아엎어야 할 수도 있을거 같슴다!

![image](https://github.com/user-attachments/assets/9880c822-c21b-4f8a-bc46-586536badbc3)
![image](https://github.com/user-attachments/assets/6bf6c9cc-4305-4f6f-ad16-23ea530d00b0)

- 일정 관련한 모든 API 토큰으로 유저 정보 받도록 해줬습니다! 

## PR 참고 사항
- 모델 지금 보니까 일정 이름은 필수로 입력해야 되더라구요! postman에서 일정 이름 없이 post요청 보내는건 되는데 장고 어드민 페이지에서 보니까 코스이름을 리턴하게 되어있어서 그런지 입력 안 하면 null로 되고, 그래서 리턴 값이 없으면 오류가 나는거 같습니다! 이 부분 확인해주세요!
