### PR TITLE
feat: 세부 일정 삭제시 순서 업데이트

### DIFF
--- a/makourse/course/views.py
+++ b/makourse/course/views.py
@@ -145,11 +145,20 @@ class ScheduleEntryDetailView(APIView):
         operation_summary="303 스케줄 속 각 일정 삭제하기",
         responses={204: "ScheduleEntry deleted successfully."}
     )
+
     def delete(self, request, pk, *args, **kwargs):
         schedule_entry = get_object_or_404(ScheduleEntry, pk=pk)
-        # ScheduleEntry 객체 가져오기
-
+        schedule = schedule_entry.schedule  # 해당 일정이 속한 스케줄 가져오기
+        
+        # 해당 일정 삭제
         schedule_entry.delete()
+
+        # 남아 있는 일정들의 num 재정렬
+        remaining_entries = ScheduleEntry.objects.filter(schedule=schedule).order_by("num")
+        for index, entry in enumerate(remaining_entries, start=0):
+            entry.num = index  # 1부터 다시 매기기
+            entry.save()
+
         return Response({"message": "ScheduleEntry deleted successfully."}, status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
<!--- 
❗️ check List 
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?

❗️ 이슈 제목은 아래의 형식을 맞춰주세요 
- feat: 기능 추가
- fix: 에러 수정, 버그 수정
- chore: gradle 세팅, 위의 것 이외에 거의 모든 것
- docs: README, 문서
- refactor: 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- modify: 코드 수정 (기능의 변화가 있을 때)
- deploy 배포 관련
-->

## Work Description 💚
- 기존에는 세부 일정 삭제할 때 순서가 업데이트 안됐습니다!
- 예를 들어 1, 2, 3, 4, 5 세부 일정 중 3번을 삭제하면 1, 2, 4, 5가 남아있었죠!
- 프론트에서 요청해서 중간 번호 삭제 시 0번(만날 장소) 부터 순서대로 정렬할 수 있도록 해줬습니다!
## PR 참고 사항
- 0번이 만날 장소 맞죠..?
- 1번이었나 0번이었나 헷갈리네......